### PR TITLE
[minor] fixed global and profile pins

### DIFF
--- a/frappe/public/js/frappe/social/components/Post.vue
+++ b/frappe/public/js/frappe/social/components/Post.vue
@@ -54,7 +54,7 @@ const Post = {
 			replies: [],
 			show_replies: false,
 			is_globally_pinnable: !this.post.reply_to && frappe.user_roles.includes('System Manager'),
-			is_pinnable: !this.post.reply_to && this.post.owner === frappe.session.user
+			is_pinnable: !this.post.reply_to && frappe.get_route()[2] === frappe.session.user
 
 		}
 	},


### PR DESCRIPTION
- global pins are now visible to admins on only main page
- profile pins are visible for only posts for all the users on their profile page.